### PR TITLE
Add UI validation save pattern and examples fixes #63

### DIFF
--- a/module-playbook-example/docs/governance/027x-ui-validation.md
+++ b/module-playbook-example/docs/governance/027x-ui-validation.md
@@ -21,6 +21,52 @@ This includes:
 - Inline edits
 - API-bound UI components
 
+```html
+<form @ref="form"
+      class="@(validated ? "was-validated" : "needs-validation")"
+      novalidate>
+
+    <!-- form fields -->
+
+    <button type="button"
+            class="btn btn-primary"
+            @onclick="Save">
+        Save
+    </button>
+</form>
+```
+Save Structure (Mandatory Execution Pattern)  
+All save operations MUST follow this structure:
+
+1. Set validation state
+2. Execute Oqtane validation
+3. Exit immediately if invalid
+4. Execute persistence logic only if valid
+
+```csharp
+@code {
+    private ElementReference form;
+    private bool validated;
+    private SampleModel model = new();
+
+    private async Task Save()
+    {
+        validated = true;
+
+        var interop = new Oqtane.UI.Interop(JS);
+
+        if (!await interop.FormValid(form))
+        {
+            return;
+        }
+
+        await SaveModelAsync(model);
+    }
+}
+```
+
+
+
 **Reject if input is accepted without validation.**
 
 ---


### PR DESCRIPTION
Introduce a mandatory Save Structure and code examples to the UI validation governance doc. Adds an HTML form example (uses validated/needs-validation classes and novalidate) and a C# sample that sets a validated flag, invokes Oqtane.UI.Interop(JS).FormValid(form), returns early if invalid, and only persists when valid. Standardizes save operations to: set validation state, execute Oqtane validation, exit if invalid, then execute persistence logic. fixes #63 