### PR TITLE
Require inner modules to extend main namespace

### DIFF
--- a/module-playbook-example/docs/governance/027x-multi-module-solution-pattern.md
+++ b/module-playbook-example/docs/governance/027x-multi-module-solution-pattern.md
@@ -27,12 +27,12 @@ Each module MUST:
 ```plaintext
 Client/
  └── Modules/
-     ├── Blog/
-     │   ├── BlogModuleInfo.cs
+     ├── AcmeCorp.Module.Inventory/
+     │   ├── InventoryModuleInfo.cs
      │   ├── Index.razor
      │   └── ...
-     └── Archive/
-         ├── ArchiveModuleInfo.cs
+     └── AcmeCorp.Module.Inventory.Reporting/
+         ├── ReportingModuleInfo.cs
          ├── Index.razor
          └── ...
 ```
@@ -43,6 +43,7 @@ Client/
 -   `ModuleInfo` class names MUST reflect the module identity
 -   Module names MUST NOT conflict with other modules in the solution
 -   Avoid reusing the solution name across multiple modules
+-   **Inner modules MUST extend the main module's namespace.** For example, if the main solution module is `AcmeCorp.Module.Inventory`, a new inner module named `Reporting` MUST use the namespace `AcmeCorp.Module.Inventory.Reporting`, NOT `AcmeCorp.Module.Reporting`.
 
 ---
 

--- a/module-playbook-example/docs/prompts/multi-module-solution.md
+++ b/module-playbook-example/docs/prompts/multi-module-solution.md
@@ -22,6 +22,7 @@ If any of the above are missing, **STOP and refuse**.
 
 You MUST:
 - Place each module in its own subfolder under `Client/Modules`.
+- Extend the main module's namespace for any new inner module (e.g., if the main module is `AcmeCorp.Module.Inventory`, a new `Reporting` module MUST use `AcmeCorp.Module.Inventory.Reporting`).
 - Ensure each module contains a `<ModuleName>ModuleInfo.cs` class with unique identifiers (`Name`, `Description`, etc.).
 - Provide a clear UI entry point (e.g., `Index.razor`) for every module.
 - Ensure module folder names and `ModuleInfo` identities are strictly unique and do not conflict.
@@ -32,6 +33,7 @@ You MUST NOT:
 - Share a single `ModuleInfo` class across multiple functional areas.
 - Create a module directory without independent registration or UI entry point.
 - Reuse the overarching solution name for a specific inner module.
+- Discard the main module's namespace root when defining an inner module's namespace.
 
 ---
 


### PR DESCRIPTION
Update governance and prompt docs to enforce that inner/child modules must extend the main module's namespace. Replaced example module names with AcmeCorp.Module.Inventory and AcmeCorp.Module.Inventory.Reporting and added explicit rules in:
- module-playbook-example/docs/governance/027x-multi-module-solution-pattern.md
- module-playbook-example/docs/prompts/multi-module-solution.md

This clarifies namespace expectations (avoid discarding the root namespace) to prevent naming conflicts and improve module organization and discoverability.