### PR TITLE
Require strict module-specific governance

### DIFF
--- a/module-playbook-example/.github/copilot-instructions.md
+++ b/module-playbook-example/.github/copilot-instructions.md
@@ -26,5 +26,6 @@ Before generating, modifying, or refactoring code, the AI must:
 - Apply all referenced governance rules
 - Refuse any request that would violate a governed rule
 - Ask for clarification if governance context is unclear
+- Follow governance strictly and provide specific module rules when applicable
 
 If governance cannot be applied, the AI must stop and explain why.


### PR DESCRIPTION
Add a guideline to .github/copilot-instructions.md requiring the AI to follow governance strictly and provide specific module rules when applicable. This clarifies expectations around applying governance and ensures module-level requirements are explicitly provided when relevant.