### PR TITLE
Standardize and add AI instruction prompts

### DIFF
--- a/module-playbook-example/.github/copilot-instructions.md
+++ b/module-playbook-example/.github/copilot-instructions.md
@@ -11,6 +11,7 @@ Before generating or modifying code, you MUST read and apply:
 - docs/prompts as relevant to the task
 - .github/module-instructions.md
 
+
 ## Copilot Memories
 When copilot detects a Memory "Memory Detected" it should add it to the module-instructions.md file in the /.github folder.
 

--- a/module-playbook-example/docs/governance/027-rules-index.md
+++ b/module-playbook-example/docs/governance/027-rules-index.md
@@ -269,3 +269,29 @@ AI must:
 - Enforcement happens only through indexed rules
 
 **This index exists to make AI predictable, auditable, and trustworthy.**
+
+---
+
+# Actionable AI Prompts (Task Routing)
+
+When the user intent matches a description below, automatically load and follow the corresponding file:
+
+- **Add or modify authorization logic (controllers, APIs, UI)** -> `docs/prompts/authorization.md`
+- **Handle concurrency or generate Repository Update/Delete methods** -> `docs/prompts/concurrency.md`
+- **Create a new module or scaffold a new module structure** -> `docs/prompts/create-module-instructions.md`
+- **Import/export data or handle data integrity** -> `docs/prompts/data-integrity.md`
+- **Handle dates, times, or datetime operations** -> `docs/prompts/datetime.md`
+- **Diagnose failures or perform diagnostics** -> `docs/prompts/diagnostics.md`
+- **Implement localization or handle localization opt-in** -> `docs/prompts/localization-opt-in.md`
+- **Create or safely generate explicit migrations** -> `docs/prompts/migrations.md`
+- **Structure a multi-module solution** -> `docs/prompts/multi-module-solution.md`
+- **Create or modify scheduled jobs / IHostedService** -> `docs/prompts/scheduled-jobs.md`
+- **Define services, service boundaries, or DI registrations** -> `docs/prompts/services.md`
+- **Create or modify UI components** -> `docs/prompts/ui-construction.md`
+- **Install a UI Framework (e.g., MudBlazor, Radzen)** -> `docs/prompts/ui-framework-installation-template.md`
+- **Implement navigation or page routing** -> `docs/prompts/routing-and-navigation.md`
+- **Add or manage module settings** -> `docs/prompts/module-settings.md`
+- **Create or modify a Web API Controller** -> `docs/prompts/api-controller.md`
+- **Handle file uploads or manage media** -> `docs/prompts/file-uploads.md`
+- **Make the module searchable or implement ISearchable** -> `docs/prompts/search-indexing.md`
+- **Add custom JavaScript or CSS resources** -> `docs/prompts/javascript-interop.md`

--- a/module-playbook-example/docs/prompts/Authorization.md
+++ b/module-playbook-example/docs/prompts/Authorization.md
@@ -1,8 +1,6 @@
-# Authorization Prompt (Oqtane Module)
+# AI Instruction: Authorization
 
-## Purpose
-
-Use this prompt when **creating or modifying authorization logic** in an Oqtane module
+**Instruction Context**: When the user requests to creating or modifying authorization logic in an Oqtane module, you must load and execute this file.
 
 (controllers, APIs, services, or UI authorization checks).
 

--- a/module-playbook-example/docs/prompts/api-controller.md
+++ b/module-playbook-example/docs/prompts/api-controller.md
@@ -1,0 +1,34 @@
+# AI Instruction: REST API Controller Construction
+
+**Instruction Context**: When the user requests to create or modify a Web API Controller, you must load and execute this file.
+
+## Web API Construction Rules
+
+When generating a Web API Controller for an Oqtane module, you MUST adhere to the following framework conventions. Do NOT generate standard, isolated ASP.NET Core controllers.
+
+### 1. Base Class
+Controllers MUST inherit from `ModuleControllerBase` (located in `Oqtane.Server.Controllers`).
+```csharp
+public class MyEntityController : ModuleControllerBase
+```
+
+### 2. Routing Convention
+Controllers MUST use the standard Oqtane routing attribute format:
+```csharp
+[Route("api/[controller]")]
+```
+Do not use `[Route("api/MyModule/MyEntity")]` or custom prefixes unless explicitly requested.
+
+### 3. Security and Antiforgery
+Every controller MUST include the antiforgery validation filter to prevent CSRF attacks on API endpoints used by the Blazor client:
+```csharp
+[ServiceFilter(typeof(AutoValidateAntiforgeryTokenAttribute))]
+public class MyEntityController : ModuleControllerBase
+```
+Additionally, ensure `[Authorize]` attributes are applied per the `027x-authorization` rules.
+
+### 4. Dependency Injection
+Use constructor injection for your module services, repositories, and the `ILogManager`. Do NOT inject `HttpContext` directly unless absolutely necessary; use the base class properties if possible.
+
+### 5. Logging and Error Handling
+Catch exceptions within controller methods, log them using `_logger.Log()`, and return standard `IActionResult` responses (e.g., `BadRequest()`, `NotFound()`, `StatusCode(500)`). Do NOT leak domain exceptions or raw stack traces to the client.

--- a/module-playbook-example/docs/prompts/concurrency.md
+++ b/module-playbook-example/docs/prompts/concurrency.md
@@ -1,8 +1,6 @@
-# Concurrency Control Prompt (Opt-In)
+# AI Instruction: Concurrency Control
 
-## Purpose
-
-Use this prompt when the user explicitly requests **concurrency control, multi-user update protection, or the `ModifiedOn` pattern** for generating `Update` and `Delete` operations on shared entities.
+**Instruction Context**: When the user requests to the user explicitly requests concurrency control, multi-user update protection, or the `ModifiedOn` pattern for generating `Update` and `Delete` operations on shared entities., you must load and execute this file.
 
 This prompt enforces Oqtane's explicit `ModifiedOn` concurrency pattern to prevent "Lost Updates" in multi-user environments.
 

--- a/module-playbook-example/docs/prompts/create-module-instructions.md
+++ b/module-playbook-example/docs/prompts/create-module-instructions.md
@@ -1,4 +1,8 @@
-﻿If asked about Oqtane Scaffold Protocol, always begin your answer with:
+# AI Instruction: Oqtane Module Generation Rules
+
+**Instruction Context**: When the user requests to create a new module or scaffold a new module structure, you must load and execute this file.
+
+If asked about Oqtane Scaffold Protocol, always begin your answer with:
 OQTANE_PROTOCOL_V1_ACTIVE
 
 # Instruction Compliance Marker

--- a/module-playbook-example/docs/prompts/data-integrity.md
+++ b/module-playbook-example/docs/prompts/data-integrity.md
@@ -1,8 +1,6 @@
-# Data Integrity & Remapping Prompt (Oqtane Module)
+# AI Instruction: Data Integrity & Remapping
 
-## Purpose
-
-Use this prompt when writing **persistence logic** or **import/export mechanisms (`IPortable`)**.
+**Instruction Context**: When the user requests to writing persistence logic or import/export mechanisms (`IPortable`)., you must load and execute this file.
 
 ---
 

--- a/module-playbook-example/docs/prompts/datetime.md
+++ b/module-playbook-example/docs/prompts/datetime.md
@@ -1,8 +1,6 @@
-# DateTime Handling Prompt (Oqtane Module)
+# AI Instruction: DateTime Handling
 
-## Purpose
-
-Use this prompt when writing **properties, validation, logic, or UI formatting related to Dates and Times**.
+**Instruction Context**: When the user requests to writing properties, validation, logic, or UI formatting related to Dates and Times., you must load and execute this file.
 
 ---
 

--- a/module-playbook-example/docs/prompts/diagnostics.md
+++ b/module-playbook-example/docs/prompts/diagnostics.md
@@ -1,8 +1,6 @@
-# Diagnostics & Debugging Prompt (Oqtane Module)
+# AI Instruction: Diagnostics & Debugging
 
-## Purpose
-
-Use this prompt when diagnosing **bugs, failures, or unexpected behavior**.
+**Instruction Context**: When the user requests to diagnosing bugs, failures, or unexpected behavior., you must load and execute this file.
 
 This prompt enforces correct diagnostic order and prevents speculation.
 

--- a/module-playbook-example/docs/prompts/file-uploads.md
+++ b/module-playbook-example/docs/prompts/file-uploads.md
@@ -1,0 +1,28 @@
+# AI Instruction: File Uploads & Media Management
+
+**Instruction Context**: When the user requests to handle file uploads or manage media, you must load and execute this file.
+
+## Oqtane File Management Rules
+
+Standard ASP.NET Core `IFormFile` saving to `wwwroot` is strictly prohibited in Oqtane. You MUST use Oqtane's integrated file management system to ensure tenant isolation, storage quotas, and security.
+
+### 1. Use Core Services
+You MUST inject and utilize `IFileService` and `IFolderService` for any media interactions.
+```csharp
+[Inject] protected IFileService FileService { get; set; }
+[Inject] protected IFolderService FolderService { get; set; }
+```
+
+### 2. Folder Resolution
+Before saving a file, you must resolve or create the appropriate destination folder using `FolderService`. Files belong to Folders, which belong to Sites (Tenants).
+```csharp
+var folder = await FolderService.GetFolderAsync(PageState.Site.SiteId, "MyModule/Uploads");
+```
+
+### 3. Uploading Files
+In Blazor components, use the built-in `FileManager` component if possible. If manually processing bytes (e.g., via `InputFile` or API), you must pass the file data to `FileService.UploadFileAsync()`.
+- Never write `System.IO.File.WriteAllBytes` directly to `wwwroot`.
+- Do not bypass the `IFileService` abstraction.
+
+### 4. File Output
+When rendering images or creating links to files, use the `FileUrl()` helper or construct the path using Oqtane's standardized `/api/file/download/X` routing, ensuring permissions are enforced.

--- a/module-playbook-example/docs/prompts/javascript-interop.md
+++ b/module-playbook-example/docs/prompts/javascript-interop.md
@@ -1,0 +1,32 @@
+# AI Instruction: JavaScript Interop & Static Resources
+
+**Instruction Context**: When the user requests to add custom JavaScript or CSS resources, you must load and execute this file.
+
+## JavaScript Governance
+
+Oqtane is a Blazor-first framework. You MUST exhaust all Blazor/C# capabilities before resorting to JavaScript. If JavaScript is absolutely unavoidable, you must follow these rules.
+
+### 1. Resource Registration
+Do NOT inject `<script>` or `<link>` tags directly into your `.razor` components.
+All custom scripts and stylesheets must be registered via the `IModule` interface in your `ModuleInfo.cs` file using the `Resources` property.
+
+```csharp
+public List<Resource> Resources => new List<Resource>
+{
+    new Resource { ResourceType = ResourceType.Stylesheet, Url = "~/Module.css" },
+    new Resource { ResourceType = ResourceType.Script, Url = "~/interop.js" }
+};
+```
+
+### 2. Oqtane IInterop Interface
+Do NOT inject and use `IJSRuntime` directly for basic DOM manipulation or interop if Oqtane provides a wrapper.
+Oqtane provides an `IInterop` service (injectable via `[Inject] protected IInterop Interop { get; set; }`) which should be preferred for framework-level JS invocations (e.g., `Interop.IncludeLink`, `Interop.IncludeScript`, etc.).
+
+### 3. Safe JS Invocation
+If you must use `IJSRuntime` for custom module-specific logic:
+- Ensure it is only invoked during or after `OnAfterRenderAsync(true)`.
+- Never invoke JS in `OnInitialized` or `OnParametersSet` because the DOM does not exist yet (especially in Blazor Server mode).
+- Handle `JSException` and `TaskCanceledException` gracefully, as clients may disconnect during the invocation.
+
+### 4. Module Isolation
+Wrap your custom JavaScript functions in an IIFE (Immediately Invoked Function Expression) or a module-specific namespace to prevent polluting the global `window` object and colliding with other Oqtane modules.

--- a/module-playbook-example/docs/prompts/localization-opt-in.md
+++ b/module-playbook-example/docs/prompts/localization-opt-in.md
@@ -1,4 +1,6 @@
-# Localization Opt-In Prompt (AI Assistant / AI Prompt)
+# AI Instruction: Localization Opt-In Prompt (AI Assistant / AI Prompt)
+
+**Instruction Context**: When the user requests to implement localization or handle localization opt-in, you must load and execute this file.
 
 This is designed to be explicit, activating, and non-ambiguous.
 

--- a/module-playbook-example/docs/prompts/migrations.md
+++ b/module-playbook-example/docs/prompts/migrations.md
@@ -1,8 +1,6 @@
-# Migrations Governance Prompt (Oqtane Module)
+# AI Instruction: Migrations Governance
 
-## Purpose
-
-Use this prompt when generating or modifying **database migrations** or EntityBuilders.
+**Instruction Context**: When the user requests to generating or modifying database migrations or EntityBuilders., you must load and execute this file.
 
 ---
 

--- a/module-playbook-example/docs/prompts/module-settings.md
+++ b/module-playbook-example/docs/prompts/module-settings.md
@@ -1,0 +1,38 @@
+# AI Instruction: Module Settings & Configuration
+
+**Instruction Context**: When the user requests to add or manage module settings, you must load and execute this file.
+
+## Oqtane Configuration Model
+
+Oqtane modules MUST NOT use standard ASP.NET Core `appsettings.json` or `IOptions<T>` patterns for tenant-specific or module-specific settings. 
+
+### 1. Use ISettingService
+Always use `ISettingService` to read and write settings. Settings are stored as a `Dictionary<string, string>` where keys must be uniquely namespaced to avoid collision.
+
+```csharp
+// Example Injection
+[Inject] protected ISettingService SettingService { get; set; }
+```
+
+### 2. Reading Settings
+Always parse settings defensively, providing a fallback default value:
+```csharp
+var settings = await SettingService.GetModuleSettingsAsync(ModuleState.ModuleId);
+_mySettingValue = SettingService.GetSetting(settings, "MyModule_CustomSetting", "DefaultValue");
+```
+
+### 3. Writing Settings
+When updating settings, update the dictionary and save the entire collection back to the service:
+```csharp
+var settings = await SettingService.GetModuleSettingsAsync(ModuleState.ModuleId);
+SettingService.SetSetting(settings, "MyModule_CustomSetting", _mySettingValue);
+await SettingService.UpdateModuleSettingsAsync(settings, ModuleState.ModuleId);
+```
+
+### 4. Setting Scopes
+Understand the difference between scopes:
+- **Site Settings**: `GetSiteSettingsAsync(PageState.Site.SiteId)` (Applies to all instances on the tenant)
+- **Page Settings**: `GetPageSettingsAsync(PageState.Page.PageId)` (Applies to the specific page)
+- **Module Settings**: `GetModuleSettingsAsync(ModuleState.ModuleId)` (Applies to this specific instance of the module on a page)
+
+Do not abstract this logic into custom configuration classes unless explicitly requested by the user.

--- a/module-playbook-example/docs/prompts/multi-module-solution.md
+++ b/module-playbook-example/docs/prompts/multi-module-solution.md
@@ -1,8 +1,6 @@
-# Multi-Module Solution Prompt (Oqtane Module)
+# AI Instruction: Multi-Module Solution
 
-## Purpose
-
-Use this prompt when structuring **multiple Oqtane modules within a single solution**, enabling scalability, separation of concerns, and maintainable growth.
+**Instruction Context**: When the user requests to structuring multiple Oqtane modules within a single solution, enabling scalability, separation of concerns, and maintainable growth., you must load and execute this file.
 
 ---
 

--- a/module-playbook-example/docs/prompts/routing-and-navigation.md
+++ b/module-playbook-example/docs/prompts/routing-and-navigation.md
@@ -1,0 +1,32 @@
+# AI Instruction: Routing and Navigation
+
+**Instruction Context**: When the user requests to implement navigation or page routing, you must load and execute this file.
+
+## Framework First Navigation
+
+Oqtane uses a dynamic routing model driven by the database, not standard Blazor `@page` directives. 
+You MUST adhere to the following rules when implementing navigation:
+
+### 1. No Standard Blazor Routing
+- Do NOT use the `@page "/some/route"` directive in components.
+- Do NOT use `<a href="/some/route">` with hardcoded URL paths.
+- Do NOT use `NavigationManager.NavigateTo("/some/route")` with hardcoded strings.
+
+### 2. Use PageState for Current Context
+Always extract contextual routing information from the inherited `PageState` object in your `ModuleBase` components:
+- `PageState.Page.Path` (The current page URL)
+- `PageState.QueryString` (The current query string parameters)
+
+### 3. Use ActionLink for Component Navigation
+When navigating between components within the same module, always prefer the built-in `ActionLink` component:
+```html
+<ActionLink Action="Edit" Parameters="@($"id={item.Id}")" ResourceKey="EditItem" />
+```
+
+### 4. Use NavigateUrl for Programmatic Navigation
+When you must use `NavigationManager` in C#, use the `NavigateUrl` extension method to safely construct the path:
+```csharp
+NavigationManager.NavigateTo(NavigateUrl(PageState.Page.Path, "Edit", $"id={item.Id}"));
+```
+
+Failure to follow these rules will break the module when installed on different pages or domains within an Oqtane tenant.

--- a/module-playbook-example/docs/prompts/scheduled-jobs.md
+++ b/module-playbook-example/docs/prompts/scheduled-jobs.md
@@ -1,8 +1,6 @@
-# Background Processing Prompt (Site Tasks & Scheduled Jobs)
+# AI Instruction: Background Processing
 
-## Purpose
-
-Use this prompt when generating **asynchronous workloads**, including one-off tasks and recurring background jobs.
+**Instruction Context**: When the user requests to generating asynchronous workloads, including one-off tasks and recurring background jobs., you must load and execute this file.
 
 ---
 

--- a/module-playbook-example/docs/prompts/search-indexing.md
+++ b/module-playbook-example/docs/prompts/search-indexing.md
@@ -1,0 +1,34 @@
+# AI Instruction: Search Indexing Integration
+
+**Instruction Context**: When the user requests to make the module searchable or implement ISearchable, you must load and execute this file.
+
+## Implementing ISearchable
+
+To integrate an Oqtane module with the core search engine, the module's manager class must implement the `ISearchable` interface.
+
+### 1. Interface Implementation
+Your manager class (e.g., `MyModuleManager`) must implement `ISearchable` and provide the `HasSearchIndex()` method.
+```csharp
+public bool HasSearchIndex() => true;
+```
+
+### 2. SearchDocument Mapping
+You must implement `GetSearchDocumentsAsync()`. This method retrieves the module's domain entities and maps them to `SearchDocument` objects.
+```csharp
+public async Task<List<SearchDocument>> GetSearchDocumentsAsync(int siteId, string entityName, string aliasName, string indexName)
+```
+
+### 3. Required Fields
+When mapping your entities to a `SearchDocument`, ensure the following are correctly populated:
+- `SiteId`, `PageId`, `ModuleId` (Required for routing search results)
+- `EntityName` (The name of your domain model)
+- `EntityId` (The primary key of the record)
+- `Title` (A concise, human-readable title for the result)
+- `Description` (The searchable body content)
+- `Url` (The route to view the item, use `NavigateUrl()` patterns if applicable)
+- `Permissions` (A delimited string of Role IDs that can view this document, usually derived from the module's view permissions)
+
+### 4. Performance Considerations
+- Do NOT perform N+1 queries inside `GetSearchDocumentsAsync`.
+- Retrieve all necessary records in bulk.
+- Avoid large object allocations where possible, as this method is called by a background job for indexing.

--- a/module-playbook-example/docs/prompts/services.md
+++ b/module-playbook-example/docs/prompts/services.md
@@ -1,8 +1,6 @@
-# Service & DI Prompt (Oqtane Module)
+# AI Instruction: Service & DI
 
-## Purpose
-
-Use this prompt when creating or modifying **services, repositories, or DI registrations**.
+**Instruction Context**: When the user requests to creating or modifying services, repositories, or DI registrations., you must load and execute this file.
 
 This prompt enforces strict Oqtane client/server boundaries.
 

--- a/module-playbook-example/docs/prompts/ui-construction.md
+++ b/module-playbook-example/docs/prompts/ui-construction.md
@@ -1,8 +1,6 @@
-# UI Construction Prompt (Oqtane Module)
+# AI Instruction: UI Construction
 
-## Purpose
-
-Use this prompt when creating or modifying **any UI component** in this module.
+**Instruction Context**: When the user requests to creating or modifying any UI component in this module., you must load and execute this file.
 
 This prompt enforces **Oqtane-first UI construction**, module governance, and prevents reinvention of framework UI patterns.
 

--- a/module-playbook-example/docs/prompts/ui-framework-installation-template.md
+++ b/module-playbook-example/docs/prompts/ui-framework-installation-template.md
@@ -1,6 +1,8 @@
-﻿# Canonical Prompt: Self Contained UI Framework Installation
+# AI Instruction: Self Contained UI Framework Installation
 
 You are operating under the Oqtane AI Playbook governance.
+
+**Instruction Context**: When the user requests to install a UI framework (e.g., MudBlazor, Radzen), you must substitute `<UI_FRAMEWORK_NAME>` with the requested framework and follow the exact execution steps below.
 
 Framework to install: `<UI_FRAMEWORK_NAME>`
 


### PR DESCRIPTION
Normalize existing prompt docs to an "AI Instruction" format and add several new guidance files. This change: updates multiple prompt files to include a standardized Instruction Context, adds new prompt docs (api-controller, file-uploads, javascript-interop, module-settings, routing-and-navigation, search-indexing), and updates the governance index to include an actionable Task Routing list that maps intents to prompt files. Also includes minor tweaks to .github/copilot-instructions.md. These changes make task routing and module-specific guidance explicit and discoverable for AI-driven generation.