### PR TITLE
Add governance doc: SysInFocus Simple-UI

### DIFF
--- a/module-playbook-example/docs/governance/027x-ui-sysinfocus.md
+++ b/module-playbook-example/docs/governance/027x-ui-sysinfocus.md
@@ -1,0 +1,169 @@
+# 027x-ui-sysinfocus
+
+Governed SysInFocus Simple-UI Integration for Oqtane Modules
+
+## Purpose
+
+This rule defines the authoritative governance contract for integrating SysInFocus Simple-UI into an Oqtane module.
+
+This rule overrides generic Blazor advice.
+
+SysInFocus Simple-UI integration must follow this document exactly.
+
+---
+
+# 1. Installation Scope Rule
+
+SysInFocus Simple-UI must be installed in:
+
+Module.Client project only
+
+It must NOT be installed in:
+
+- Oqtane host project
+- Oqtane core framework
+- Server project
+
+The module owns its UI framework dependency.
+
+---
+
+# 2. Package Installation
+
+Add the NuGet package to Module.Client:
+
+Important: Follow the 027x-packaging-and-dependencies.md to ensure that the package is properly installed and configured.
+
+SysInFocus.UI (or the relevant Simple-UI package)
+
+The version must be explicitly defined.
+
+No floating versions.
+
+---
+
+# 3. Service Registration Rule
+
+SysInFocus Simple-UI services must be registered in:
+
+Module.Client Startup class or ClientStartup.cs
+
+Example:
+
+```csharp
+using SysInFocus; // or appropriate namespace
+
+services.AddSysInFocus(); // or appropriate registration method
+```
+
+Do NOT:
+
+- Register services in Oqtane host Program.cs
+- Register services in Server project
+- Register dynamically at runtime
+
+Service registration belongs to the module.
+
+---
+
+# 4. Required Provider Rule
+
+Any required providers or components must exist in the module layout. For example, if a Theme or Dialog provider is needed:
+
+```razor
+<!-- Add appropriate SysInFocus root components here -->
+```
+
+They must be rendered once per module render surface.
+
+If missing, the module is considered misconfigured.
+
+---
+
+# 5. Static Web Assets Rule
+
+SysInFocus Simple-UI static web assets must follow:
+
+027x-packaging-and-dependencies.md
+
+Assets must resolve through:
+
+\_content/SysInFocus.UI/ (or actual package id)
+
+No direct file copying into host.
+
+No manual CSS duplication.
+
+Packaging rule governs physical deployment.
+
+---
+
+# 6. Host Isolation Rule
+
+SysInFocus Simple-UI integration must NOT modify:
+
+- Oqtane host Program.cs
+- Global index.html
+- Core Oqtane layout
+- Global Bootstrap configuration
+
+Modules must remain portable.
+
+Host pollution is forbidden.
+
+---
+
+# 7. UI Consistency Rule
+
+Do not mix SysInFocus Simple-UI components with:
+
+- Bootstrap UI components
+- Radzen components
+- MudBlazor components
+- Other UI frameworks
+
+Within the same render surface unless explicitly governed.
+
+UI fragmentation is not allowed.
+
+---
+
+# 8. Runtime Awareness
+
+If runtime detection indicates conflicting UI frameworks are already registered, the AI must:
+
+- Notify
+- Require explicit override
+- Not auto-mix frameworks
+
+UI framework conflicts must be deliberate, never accidental.
+
+---
+
+# 9. Packaging Compliance
+
+SysInFocus Simple-UI dependency must be reflected in:
+
+- project.assets.json
+- nuspec packaging if required
+- static web asset inclusion
+
+Packaging must comply with 027x-packaging-and-dependencies.md.
+
+---
+
+# 10. AI Enforcement Behavior
+
+When user requests:
+
+"Add SysInFocus Simple-UI"
+
+AI must:
+
+1. Add package to Module.Client
+2. Register services in ClientStartup
+3. Add required providers
+4. Validate packaging compliance
+5. Refuse host modification
+
+No alternative interpretations.


### PR DESCRIPTION
Add module-playbook-example/docs/governance/027x-ui-sysinfocus.md that defines the authoritative integration contract for SysInFocus Simple-UI in Oqtane modules. The document mandates Module.Client-only installation, explicit package versions, service registration in ClientStartup, required provider rendering, static web asset handling, host isolation, UI consistency rules, runtime conflict handling, packaging compliance, and AI enforcement steps. It references 027x-packaging-and-dependencies.md and overrides generic Blazor advice.