### PR TITLE
Add SysInFocus UI to rules index

### DIFF
--- a/module-playbook-example/docs/governance/027-rules-index.md
+++ b/module-playbook-example/docs/governance/027-rules-index.md
@@ -226,6 +226,8 @@ Blazor Bootstrap allowed only when explicitly requested.
 Fluent UI allowed only when explicitly requested.
 - **027x-ui-mudblazor.md**
 MudBlazor allowed only when explicitly requested.
+- **027x-ui-sysinfocus.md**
+SysInFocus Simple-UI allowed only when explicitly requested.
 - **027x-ui-radzen.md**
 Radzen allowed only when explicitly requested.
 


### PR DESCRIPTION
Insert a new entry for 027x-ui-sysinfocus.md into the governance rules index to mark SysInFocus Simple-UI as allowed only when explicitly requested. Updates module-playbook-example/docs/governance/027-rules-index.md.