### PR TITLE
Add caching governance and docs; tweak routing

### DIFF
--- a/docs/000-quick-reference.md
+++ b/docs/000-quick-reference.md
@@ -1,4 +1,4 @@
-﻿# Quick Reference - What This Playbook Stops AI From Doing
+# Quick Reference - What This Playbook Stops AI From Doing
 
 This card lists the **top rejection rules** from the Oqtane AI Playbook in plain language.
 
@@ -103,6 +103,7 @@ If AI-generated code violates any of these, **reject it immediately.**
 | Error handling | `015-Error-Handling.md` | `027x-error-handling.md` |
 | Packaging | `020-packaging-and-dependencies.md` | `027x-packaging-and-dependencies.md` |
 | Client/server boundaries | `017-Client-Server-Responsibility-Boundaries.md` | `027x-execution-parity.md` |
+| Caching | `035-caching.md` | `027x-caching.md` |
 
 ---
 

--- a/docs/035-caching.md
+++ b/docs/035-caching.md
@@ -1,0 +1,18 @@
+# 035 - Caching Governance
+
+Oqtane 10.2.0 introduced `CacheManager` (wrapping FusionCache) to standardize caching across the framework and guarantee multi-tenant safety.
+
+## The Problem
+
+Using `IMemoryCache` or `IDistributedCache` directly in a multi-tenant environment risks cross-tenant data leakage if cache keys are not correctly namespaced with the `SiteId` or `TenantId`. Additionally, developers often reimplement cache-aside patterns, which introduces subtle bugs.
+
+## The Solution
+
+For Oqtane 10.2.0 and later, always use the framework-provided `CacheManager` (or equivalent framework caching abstraction) for caching in Oqtane modules. The framework automatically handles standardizing cache key formats, cache failsafes, and supporting multi-tenancy correctly.
+
+## Rules
+
+- Never use `IMemoryCache` or `IDistributedCache` directly.
+- Never use static variables, dictionaries, or singleton collections for caching data.
+- Ensure caching configuration utilizes framework standard parameters (e.g. `MemoryCacheDuration`, `DistributedCacheDuration`) where applicable.
+- Let the framework dictate the cache expiration policy via `CacheManager`.

--- a/module-playbook-example/docs/governance/027-rules-index.md
+++ b/module-playbook-example/docs/governance/027-rules-index.md
@@ -173,6 +173,8 @@ Site Tasks must not be implemented in Oqtane versions earlier than 10.1.
 - **027x-javascript-usage.md**
 JavaScript must not be introduced unless a Blazor based C# solution is demonstrably insufficient.  
 Opt in, not default.  
+- **027x-caching.md**
+Governance for caching implementations. Requires use of `CacheManager` in Oqtane 10.2+ and forbids direct use of `IMemoryCache` to ensure multi-tenant safety.
 
 ---
 
@@ -300,3 +302,4 @@ When the user intent matches a description below, automatically load and follow 
 - **Handle file uploads or manage media** -> `docs/prompts/file-uploads.md`
 - **Make the module searchable or implement ISearchable** -> `docs/prompts/search-indexing.md`
 - **Add custom JavaScript or CSS resources** -> `docs/prompts/javascript-interop.md`
+- **Implement or modify caching logic** -> `docs/prompts/caching.md`

--- a/module-playbook-example/docs/governance/027x-caching.md
+++ b/module-playbook-example/docs/governance/027x-caching.md
@@ -1,0 +1,56 @@
+# 027x Caching Governance
+
+## Purpose
+
+This rule governs caching implementations within Oqtane modules. Oqtane 10.2.0 introduced `CacheManager` (wrapping FusionCache) to provide a multi-tenant safe abstraction over distributed and memory caching.
+
+---
+
+## 1. Version Gate (Runtime-Aware Governance)
+
+The `CacheManager` abstraction is available in **Oqtane 10.2.0 or greater**.
+
+Before generating caching logic, AI must verify the framework version.
+
+If Version < 10.2.0:
+- Standard `IMemoryCache` is permissible, but keys **must** be explicitly prefixed with the `SiteId` to prevent cross-tenant data bleeding.
+
+If Version >= 10.2.0:
+- Use `CacheManager` natively provided by the framework.
+- `IMemoryCache` and `IDistributedCache` must not be used directly.
+
+---
+
+## 2. Allowed Cache Mechanism (10.2.0+)
+
+Modules must strictly use the framework-provided `CacheManager` abstraction for caching needs. The framework handles standardizing cache key formats and supporting multi-tenancy.
+
+**Reject if:**
+- `IMemoryCache` is injected or used directly.
+- `IDistributedCache` is injected or used directly.
+- Static dictionaries, fields, or singletons are used to cache data in memory.
+- Custom cache-aside logic is manually implemented using generic abstractions instead of `CacheManager`.
+
+---
+
+## 3. Cache Keys and Multi-Tenancy
+
+Oqtane's `CacheManager` automatically handles key standardization and multi-tenant scoping if implemented through the framework abstractions. 
+
+AI must explicitly rely on the `CacheManager` caching primitives instead of manually concatenating `TenantId` or `SiteId` into strings when interacting with the cache, unless the specific framework API explicitly requires it.
+
+---
+
+## 4. Cache Durations
+
+When specifying cache durations, utilize `TimeSpan` parameters. If applicable, defer to configuration options exposed by the framework or module settings (e.g. `MemoryCacheDuration`, `DistributedCacheDuration`) rather than hardcoding arbitrary expiration values.
+
+---
+
+## 5. AI Enforcement Behavior
+
+If the user requests caching logic, AI must:
+1. Validate the Oqtane version.
+2. Inject the framework `CacheManager` abstraction in server services if >= 10.2.0.
+3. Refuse to use raw `IMemoryCache` or `IDistributedCache` on modern versions.
+4. Refuse the creation of static state properties for caching purposes.

--- a/module-playbook-example/docs/prompts/caching.md
+++ b/module-playbook-example/docs/prompts/caching.md
@@ -1,0 +1,37 @@
+# AI Instruction: Caching Governance
+
+**Instruction Context**: When the user requests to add caching, improve performance via cache, or store temporary data across requests, you must load and execute this file.
+
+---
+
+## Mandatory Context
+
+Before responding, you MUST:
+
+1. Read `docs/governance/027x-caching.md`
+2. Verify Oqtane framework version using runtime awareness principles.
+
+If the above file is missing or inaccessible, **STOP and refuse**.
+
+---
+
+## Caching Rules (Non-Negotiable)
+
+You MUST:
+- Use the framework-provided `CacheManager` abstraction if the Oqtane version is 10.2.0 or greater.
+- Define cache durations using `TimeSpan`.
+- Rely on framework APIs to guarantee multi-tenant cache isolation.
+
+You MUST NOT:
+- Use `IMemoryCache` or `IDistributedCache` directly in modern Oqtane modules.
+- Use static fields, dictionaries, or singletons to hold state or cache data across requests.
+- Implement custom background workers to invalidate cache entries when framework events or expiration policies exist.
+
+---
+
+## Expected Output
+- Explicit injection of `CacheManager` in server-side services.
+- Clean cache-aside patterns.
+- Clear multi-tenant safety.
+
+If uncertain about framework support, **REFUSE and explain why**.

--- a/module-playbook-example/docs/prompts/routing-and-navigation.md
+++ b/module-playbook-example/docs/prompts/routing-and-navigation.md
@@ -7,8 +7,9 @@
 Oqtane uses a dynamic routing model driven by the database, not standard Blazor `@page` directives. 
 You MUST adhere to the following rules when implementing navigation:
 
-### 1. No Standard Blazor Routing
-- Do NOT use the `@page "/some/route"` directive in components.
+### 1. Blazor Routing Constraints
+- In Oqtane versions < 10.1.0, do NOT use the `@page "/some/route"` directive in components.
+- In Oqtane versions >= 10.1.0, `@page` and `@attribute` are supported and may specify aliases and page order. However, for module-specific views, dynamic routing via `ActionLink` remains the primary pattern unless explicitly defining a standalone route.
 - Do NOT use `<a href="/some/route">` with hardcoded URL paths.
 - Do NOT use `NavigationManager.NavigateTo("/some/route")` with hardcoded strings.
 


### PR DESCRIPTION
Add comprehensive caching governance for Oqtane (CacheManager / FusionCache) and related AI prompt guidance, plus update indexes and quick-reference. Files added: docs/035-caching.md (high-level guidance), module-playbook-example/docs/governance/027x-caching.md (runtime-aware rule enforcing CacheManager for Oqtane >= 10.2.0 and forbidding direct IMemoryCache/IDistributedCache or static caches), and module-playbook-example/docs/prompts/caching.md (AI instruction to validate version and inject CacheManager or refuse). Also updated docs/000-quick-reference.md and module-playbook-example/docs/governance/027-rules-index.md to reference caching, and adjusted module-playbook-example/docs/prompts/routing-and-navigation.md to clarify @page usage across Oqtane versions.